### PR TITLE
Call to custom make_unique

### DIFF
--- a/src/cuNSearch.cu
+++ b/src/cuNSearch.cu
@@ -40,7 +40,7 @@ namespace cuNSearch
 {
 	NeighborhoodSearch::NeighborhoodSearch(Real searchRadius)
 	{
-		deviceData = std::make_unique<cuNSearchDeviceData>(searchRadius);
+		deviceData = make_unique<cuNSearchDeviceData>(searchRadius);
 		set_radius(searchRadius);
 	}
 


### PR DESCRIPTION
Changed call to std::make_unique to the custom make_unique.
I had some compilation errors while building SPlisHSPlasH with USE_GPU_NEIGHBORHOOD_SEARCH option, because std::make_unique is only available in C++14 . When I tried to solve this problem, I saw that there was one use of std::make_unique instead of the custom make_unique.
This might be intentional because PR #13 was merged, in that case, close this one and I apologize for the inconvenience.
In either case, the real problem is the git tag in the cmake of SPlisHSPlasH. I can do a PR to update it when this one is merged/closed.