### PR TITLE
Small Change on the CMakeLists in order to include the library in other projects using fetch_content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ target_include_directories(cuNSearch PUBLIC
 	"Utils"
 	${CUDA_INCLUDE_DIRS}
 	${CMAKE_CURRENT_BINARY_DIR}/cuNSearch
+	${CMAKE_BINARY_DIR}/cuNSearch
 )
 target_link_libraries(cuNSearch PUBLIC ${CUDA_LIBRARIES})
 target_compile_definitions(cuNSearch PUBLIC $<$<CONFIG:DEBUG>:DEBUG>)
@@ -96,7 +97,7 @@ install(TARGETS cuNSearch
 	)
 
 option(BUILD_DEMO "Build example of how to use this library."
-		ON)
+		OFF)
 if(BUILD_DEMO)
 	add_subdirectory(demo)
 endif(BUILD_DEMO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ target_include_directories(cuNSearch PUBLIC
 	"include"
 	"Utils"
 	${CUDA_INCLUDE_DIRS}
-	${CMAKE_BINARY_DIR}/cuNSearch
+	${CMAKE_CURRENT_BINARY_DIR}/cuNSearch
 )
 target_link_libraries(cuNSearch PUBLIC ${CUDA_LIBRARIES})
 target_compile_definitions(cuNSearch PUBLIC $<$<CONFIG:DEBUG>:DEBUG>)


### PR DESCRIPTION
When I include the cuNSearch in other projects using fetch_content, the folders ${CMAKE_BINARY_DIR} and ${CMAKE_CURRENT_BINARY_DIR} are different, and the cmake target cuNSearch does not include the correct folder. 

I think this would be a good fix for that, without breaking any other project.